### PR TITLE
修复配置地址显示问题

### DIFF
--- a/internal/mytv/utils.go
+++ b/internal/mytv/utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"net/http"
 )
 
@@ -12,6 +13,11 @@ func Lan() (lanIp string) {
 	interfaces, err := net.Interfaces()
 	if err == nil {
 		for _, i := range interfaces {
+
+			if strings.HasPrefix(i.Name, "VMnet") || strings.HasPrefix(i.Name, "VirtualBox") {
+				continue
+			}
+
 			var addrs []net.Addr
 			addrs, err = i.Addrs()
 			if err != nil {
@@ -20,7 +26,7 @@ func Lan() (lanIp string) {
 			}
 
 			for _, a := range addrs {
-				if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() && ipNet.IP.To4() != nil {
+				if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() && !ipNet.IP.IsLinkLocalUnicast() && ipNet.IP.To4() != nil {
 					lanIp = ipNet.IP.String()
 					break
 				}


### PR DESCRIPTION
添加 `IsLinkLocalUnicast`、 `strings.HasPrefix` （过滤 VMware 和 VirtualBox 的虚拟网卡） 以解决  #2  